### PR TITLE
Add quick install command to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@
 
 [Architecture](#routing-map) · [Skill Setup](#skill-setup) · [Quick Setup](#quick-setup) · [Full MCP Configs](#mcp-setup--all-8-clients) · [Env Vars](#environment-variables)
 
+```bash
+npm i designer-skill-mcp
+```
+
 </div>
 
 ---


### PR DESCRIPTION
Adds `npm i designer-skill-mcp` as a quick install snippet near the top of the README, between the nav links and the closing `</div>`.