### PR TITLE
Release designer-skill-mcp v0.12.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "designer-skill",
   "displayName": "designer-skill",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "Plug-and-play MCP that gives your agent UI superpowers. One install: design skill + MCP server, zero config.",
   "author": {
     "name": "Pythoughts Labs",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "designer-skill",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "Plug-and-play MCP that gives your agent UI superpowers. One install: design skill + MCP server, zero config.",
   "repository": "https://github.com/Pythoughts-labs/designer-skill",
   "license": "MIT",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "designer-skill",
   "displayName": "designer-skill",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "Plug-and-play MCP: UI superpowers, design references, anti-slop ship gate.",
   "author": {
     "name": "Pythoughts Labs",

--- a/designer-skill-mcp/package-lock.json
+++ b/designer-skill-mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "designer-skill-mcp",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "designer-skill-mcp",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/designer-skill-mcp/package.json
+++ b/designer-skill-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "designer-skill-mcp",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "mcpName": "io.github.pythoughts-labs/designer-skill-mcp",
   "description": "Plug-and-play MCP that gives your coding agent UI superpowers: design tools, reference docs, and anti-slop checks.",
   "type": "module",

--- a/designer-skill-mcp/server.json
+++ b/designer-skill-mcp/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/Pythoughts-labs/designer-skill",
     "source": "github"
   },
-  "version": "0.11.0",
+  "version": "0.12.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "designer-skill-mcp",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
Version bump to **0.12.0** across all touchpoints (package.json, package-lock, server.json, .claude-plugin, .codex-plugin, .cursor-plugin).

### Included since v0.11.0
- **feat:** MCP connect-time `instructions` field — agents get a routing orientation (`get_preflight_brief` → commit direction → dispatch → gate) the moment the server connects.
- **refactor:** tightened preflight brief, SKILL.md router, and tool-description prose (substance unchanged, token budgets held).
- **ci:** build + 55-test suite now runs on PRs and main.

Build + `npm test` green locally (55 passing). npm publish + GitHub release follow once this lands on main.