### PR TITLE
feat(designer-skill): add css-techniques reference for CSS implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 <br />
 
 [![agents](https://img.shields.io/badge/agents-8-7c3aed?style=for-the-badge)](#setup)
-[![references](https://img.shields.io/badge/references-13-e11d48?style=for-the-badge)](#reference)
+[![references](https://img.shields.io/badge/references-15-e11d48?style=for-the-badge)](#reference)
 [![tools](https://img.shields.io/badge/MCP_tools-10-0ea5e9?style=for-the-badge)](#tools)
 [![detector](https://img.shields.io/badge/detector-44_rules-f59e0b?style=for-the-badge)](#tools)
 
@@ -45,7 +45,7 @@ npm i designer-skill-mcp
 
 ### Know
 
-13 reference files cover type, color, motion, a11y, anti-slop, and redesign loops. Your agent reads the right file before writing UI code.
+15 reference files cover type, color, motion, a11y, anti-slop, and redesign loops. Your agent reads the right file before writing UI code.
 
 </td>
 <td width="33%" valign="top" bgcolor="#faf5ff">
@@ -87,7 +87,7 @@ Add the server. Ask in plain language. The agent handles the rest.
 
 <div align="center">
 
-[![skill](https://img.shields.io/badge/design_skill-13_refs-7c3aed?style=flat-square)](skills/designer-skill/)
+[![skill](https://img.shields.io/badge/design_skill-15_refs-7c3aed?style=flat-square)](skills/designer-skill/)
 [![mcp](https://img.shields.io/badge/MCP-10_tools-0ea5e9?style=flat-square)](designer-skill-mcp/)
 
 **Built with it:** [pythinker.com](https://pythinker.com) — a live production site designed end-to-end with this skill.
@@ -324,6 +324,7 @@ Use designer-skill to redesign this pricing page without breaking functionality.
 </thead>
 <tbody>
 <tr><td bgcolor="#fff1f2"><code>design-principles.md</code></td><td bgcolor="#f8fafc">Typography, spacing, color, layout, hierarchy (neutral baseline)</td><td align="center" bgcolor="#eff6ff"><b>core</b></td></tr>
+<tr><td bgcolor="#fdf4ff"><code>differentiation-playbook.md</code></td><td bgcolor="#f8fafc">How to be distinctive: inverse test, layout menu, one weird thing, named references</td><td align="center" bgcolor="#eff6ff"><b>core</b></td></tr>
 <tr><td bgcolor="#fff7ed"><code>aesthetic-systems.md</code></td><td bgcolor="#f8fafc">Picking a look: 5 systems with palettes, fonts, shadows</td><td align="center" bgcolor="#eff6ff"><b>core</b></td></tr>
 <tr><td bgcolor="#faf5ff"><code>motion-and-interaction.md</code></td><td bgcolor="#f8fafc">Animation timing, springs, scroll, reduced-motion</td><td align="center" bgcolor="#eff6ff"><b>core</b></td></tr>
 <tr><td bgcolor="#ecfdf5"><code>engineering-and-performance.md</code></td><td bgcolor="#f8fafc">Tokens, a11y, responsive, Core Web Vitals, real-data hardening</td><td align="center" bgcolor="#eff6ff"><b>core</b></td></tr>
@@ -336,13 +337,14 @@ Use designer-skill to redesign this pricing page without breaking functionality.
 <tr><td bgcolor="#ecfdf5"><code>project-init.md</code></td><td bgcolor="#f8fafc">Discovery interview, PRODUCT.md, DESIGN.md setup</td><td align="center" bgcolor="#fdf2f8"><b>extended</b></td></tr>
 <tr><td bgcolor="#faf5ff"><code>craft-flow.md</code></td><td bgcolor="#f8fafc">Shape-then-build pipeline with user gates</td><td align="center" bgcolor="#fdf2f8"><b>extended</b></td></tr>
 <tr><td bgcolor="#f0f9ff"><code>live-mode.md</code></td><td bgcolor="#f8fafc">Browser variant mode: element select, HMR, poll/steer/accept</td><td align="center" bgcolor="#fdf2f8"><b>extended</b></td></tr>
+<tr><td bgcolor="#fff7ed"><code>css-techniques.md</code></td><td bgcolor="#f8fafc">Modern CSS cookbook: resets, centering, selectors, logical props, container queries, <code>:has()</code>, <code>clamp()</code></td><td align="center" bgcolor="#fdf2f8"><b>extended</b></td></tr>
 </tbody>
 </table>
 
 <div align="center">
 
-[![core](https://img.shields.io/badge/core-7-0ea5e9?style=flat-square)](#reference)
-[![extended](https://img.shields.io/badge/extended-6-e11d48?style=flat-square)](#reference)
+[![core](https://img.shields.io/badge/core-8-0ea5e9?style=flat-square)](#reference)
+[![extended](https://img.shields.io/badge/extended-7-e11d48?style=flat-square)](#reference)
 
 </div>
 
@@ -413,7 +415,7 @@ Use designer-skill to redesign this pricing page without breaking functionality.
 <tbody>
 <tr><td bgcolor="#f0f9ff"><code>get_design_system</code></td><td bgcolor="#f8fafc">SKILL.md router (call first)</td></tr>
 <tr><td bgcolor="#ecfdf5"><code>load_project_context</code></td><td bgcolor="#f8fafc">Read PRODUCT.md / DESIGN.md from the project</td></tr>
-<tr><td bgcolor="#faf5ff"><code>get_reference</code></td><td bgcolor="#f8fafc">One of thirteen reference files by name</td></tr>
+<tr><td bgcolor="#faf5ff"><code>get_reference</code></td><td bgcolor="#f8fafc">One of fifteen reference files by name</td></tr>
 <tr><td bgcolor="#fff7ed"><code>list_commands</code></td><td bgcolor="#f8fafc">All design verbs with descriptions</td></tr>
 <tr><td bgcolor="#eff6ff"><code>get_command</code></td><td bgcolor="#f8fafc">Full guidance + references for a specific verb</td></tr>
 <tr><td bgcolor="#fdf4ff"><code>dispatch_intent</code></td><td bgcolor="#f8fafc">Map a request → verb(s) + files to read</td></tr>

--- a/designer-skill-mcp/README.md
+++ b/designer-skill-mcp/README.md
@@ -29,7 +29,7 @@ mcp-publisher publish
 |---|---|
 | `get_design_system` | SKILL.md router (call first) |
 | `load_project_context` | Read PRODUCT.md / DESIGN.md from the project |
-| `get_reference` | One of thirteen reference files by name |
+| `get_reference` | One of fifteen reference files by name |
 | `list_commands` | All design verbs with descriptions |
 | `get_command` | Full guidance + references for a specific verb |
 | `dispatch_intent` | Map a request ("make it pop", "it feels off") to design verb(s) + files |

--- a/designer-skill-mcp/src/dispatch.ts
+++ b/designer-skill-mcp/src/dispatch.ts
@@ -37,8 +37,8 @@ const VERBS: Verb[] = [
   {
     verb: "check",
     cues: ["check", "audit", "review the", "review my", "check the", "a11y", "accessibility", "performance review", "responsive check", "lighthouse"],
-    files: ["engineering-and-performance", "avoid-ai-slop", "refactor-and-redesign"],
-    note: "Technical audit (a11y, perf, responsive, anti-patterns). Report findings; fix nothing yet.",
+    files: ["engineering-and-performance", "avoid-ai-slop", "refactor-and-redesign", "css-techniques"],
+    note: "Technical audit (a11y, perf, responsive, CSS anti-patterns). Report findings; fix nothing yet.",
   },
   {
     verb: "review",
@@ -49,8 +49,8 @@ const VERBS: Verb[] = [
   {
     verb: "finish",
     cues: ["finish", "polish", "final pass", "tighten", "before shipping", "ship ready", "refine", "clean up the ui"],
-    files: ["design-principles", "engineering-and-performance"],
-    note: "Final polish: spacing scale, interaction states, optical alignment.",
+    files: ["design-principles", "engineering-and-performance", "css-techniques"],
+    note: "Final polish: spacing scale, interaction states, optical alignment, idiomatic CSS.",
   },
   {
     verb: "amplify",
@@ -85,8 +85,8 @@ const VERBS: Verb[] = [
   {
     verb: "layout",
     cues: ["layout", "spacing", "feels off", "alignment", "hierarchy", "grid", "whitespace", "cramped", "looks off"],
-    files: ["design-principles"],
-    note: "Fix spacing, rhythm, hierarchy: 4pt scale, flex/grid, squint test.",
+    files: ["design-principles", "css-techniques"],
+    note: "Fix spacing, rhythm, hierarchy: 4pt scale, flex/grid, subgrid, container queries, squint test.",
   },
   {
     verb: "type",
@@ -103,13 +103,13 @@ const VERBS: Verb[] = [
   {
     verb: "ship",
     cues: ["ship", "harden", "production-ready", "production ready", "edge case", "real data", "empty state", "error state", "i18n", "loading state", "rtl"],
-    files: ["engineering-and-performance"],
-    note: "Production-ready: long/empty/RTL text, API errors, no fixed text widths.",
+    files: ["engineering-and-performance", "css-techniques"],
+    note: "Production-ready: long/empty/RTL text, API errors, no fixed text widths, logical properties.",
   },
   {
     verb: "speed",
     cues: ["speed", "optimize", "optimise", "slow", "janky", "jank", "lag", "fps", "bundle size", "performance issue", "core web vitals"],
-    files: ["engineering-and-performance"],
+    files: ["engineering-and-performance", "css-techniques"],
     note: "Fix UI performance: measure first, fix the real bottleneck.",
   },
   {
@@ -133,14 +133,14 @@ const VERBS: Verb[] = [
   {
     verb: "responsive",
     cues: ["responsive", "adapt", "mobile", "tablet", "different device", "breakpoint", "small screen", "touch"],
-    files: ["engineering-and-performance", "refactor-and-redesign"],
-    note: "Rethink for target device: reflow, touch targets, safe areas.",
+    files: ["engineering-and-performance", "refactor-and-redesign", "css-techniques"],
+    note: "Rethink for target device: reflow, container queries, touch targets, safe areas.",
   },
   {
     verb: "refresh",
     cues: ["refresh", "redesign", "improve existing", "fix this ui", "without breaking", "revamp", "modernize", "modernise", "existing site", "existing app", "upgrade the design"],
-    files: ["refactor-and-redesign", "avoid-ai-slop"],
-    note: "Improve existing UI without breaking it: audit, diagnose, redesign loop.",
+    files: ["refactor-and-redesign", "avoid-ai-slop", "css-techniques"],
+    note: "Improve existing UI without breaking it: audit, diagnose, redesign loop, modern CSS.",
   },
   {
     verb: "copy",
@@ -195,6 +195,12 @@ const VERBS: Verb[] = [
     cues: ["design system", "token system", "naming convention", "theming", "design tokens", "dark mode system", "component library", "token architecture"],
     files: ["design-systems", "engineering-and-performance"],
     note: "Token architecture, component specs, theming, naming conventions.",
+  },
+  {
+    verb: "css",
+    cues: ["css", "stylesheet", "tailwind", "css fix", "fix the css", "css bug", "selector", "specificity", "centering", "center this", "aspect-ratio", "container query", ":has", "logical properties", "flexbox", "css grid", "clamp", "box-sizing", "css reset"],
+    files: ["css-techniques", "design-principles"],
+    note: "Apply idiomatic modern CSS: resets, centering, selectors, specificity (@layer/:is), logical properties, container queries, clamp(), :has().",
   },
 ];
 

--- a/designer-skill-mcp/src/server.ts
+++ b/designer-skill-mcp/src/server.ts
@@ -64,7 +64,7 @@ export function createServer(): McpServer {
     }),
     {
       title: "designer-skill reference",
-      description: "One of the fourteen designer-skill reference files.",
+      description: "One of the fifteen designer-skill reference files.",
       mimeType: "text/markdown",
     },
     async (uri, variables) => {

--- a/designer-skill-mcp/src/skill.ts
+++ b/designer-skill-mcp/src/skill.ts
@@ -20,6 +20,7 @@ export const REFERENCE_NAMES = [
   "project-init",
   "craft-flow",
   "live-mode",
+  "css-techniques",
 ] as const;
 
 export type ReferenceName = (typeof REFERENCE_NAMES)[number];
@@ -53,6 +54,8 @@ export const REFERENCE_DESCRIPTIONS: Record<ReferenceName, string> = {
     "Full shape-then-build pipeline with user gates, framework detection, visual iteration loop, and production-grade output.",
   "live-mode":
     "Interactive browser variant mode: element selection, hot-swapped HTML+CSS variants via HMR, poll/steer/accept contract.",
+  "css-techniques":
+    "Modern CSS implementation cookbook: resets, box-sizing, centering, aspect-ratio, :is()/:not(), logical properties, container queries, :has(), @layer, clamp(), Baseline-bucketed features. The how-to for applying CSS fixes.",
 };
 
 function resolveSkillDir(): string {

--- a/designer-skill-mcp/test/server.test.ts
+++ b/designer-skill-mcp/test/server.test.ts
@@ -89,6 +89,10 @@ describe("dispatchIntent", () => {
     expect(r.matched).toHaveLength(0);
     expect(r.recommendedReads).toContain("command-playbook");
   });
+  it("routes CSS fixes to the css-techniques reference", () => {
+    expect(dispatchIntent("fix the css").recommendedReads).toContain("css-techniques");
+    expect(dispatchIntent("center this with flexbox").recommendedReads).toContain("css-techniques");
+  });
 });
 
 describe("designer-skill MCP server", () => {
@@ -198,7 +202,7 @@ describe("designer-skill MCP server", () => {
     expect(text).toContain("Avoiding AI Slop");
   });
 
-  it("exposes the skill router resource and all fourteen reference resources", async () => {
+  it("exposes the skill router resource and all fifteen reference resources", async () => {
     const uris = (await client.listResources()).resources.map((r) => r.uri);
     expect(uris).toContain("designer://skill");
     for (const name of REFERENCE_NAMES) {

--- a/skills/designer-skill/SKILL.md
+++ b/skills/designer-skill/SKILL.md
@@ -9,7 +9,7 @@ A plug-and-play MCP that gives your agent UI superpowers: design, refactor, and 
 
 **Foundation:** Brief by default → commit direction before code → deep refs on demand → deterministic gate before done.
 
-This file is the router. Substance lives in fourteen reference files under `reference/`; load them on demand via MCP — do not work from memory.
+This file is the router. Substance lives in fifteen reference files under `reference/`; load them on demand via MCP — do not work from memory.
 
 ## MCP workflow (every UI task)
 
@@ -18,9 +18,9 @@ When the **designer-skill** MCP server is connected:
 1. **`get_preflight_brief`** — compact binding rules (~500 tokens). Call first.
 2. **`commit_design_direction`** — declare register, aesthetic, physical scene, layouts, type direction, anti-slop risks, inverse test. Must **PASS** before code.
 3. **`load_project_context`** — PRODUCT.md / DESIGN.md when present. If `NO_PRODUCT_MD` on greenfield, run `get_command({ verb: "setup" })`.
-4. **`dispatch_intent`** — map the user's request to verb(s) + which references to load (2–4 files, not all fourteen).
+4. **`dispatch_intent`** — map the user's request to verb(s) + which references to load (2–4 files, not all fifteen).
 5. **`get_reference`** — load only the files `dispatch_intent` recommends.
-6. Implement.
+6. Implement. When writing or fixing CSS, pull `get_reference({ name: "css-techniques" })` for idiomatic patterns (centering, specificity, logical properties, container queries, `:has()`, `clamp()`).
 7. **`review_and_gate`** — scan changed files; score ≥85, zero blocking slop. Do not claim done on **FAIL**.
 
 Optional: `get_palette_seed` on greenfield (no committed brand colors); `detect_antipatterns` for ad-hoc scans; web-search MCP for contemporary UI references on visually-led net-new work (extract moves, don't copy layouts).
@@ -58,6 +58,7 @@ If MCP is unavailable, read local `reference/` files using the routing map below
 | `reference/project-init.md` | Discovery, PRODUCT.md, DESIGN.md setup |
 | `reference/craft-flow.md` | Shape-then-build pipeline with user gates |
 | `reference/live-mode.md` | Browser variant mode: HMR hot-swap |
+| `reference/css-techniques.md` | **How to write the CSS** — resets, centering, selectors/specificity, logical properties, container queries, `:has()`, `clamp()`; the cookbook for applying CSS fixes |
 
 ## Precedence rule
 
@@ -71,6 +72,7 @@ If MCP is unavailable, read local `reference/` files using the routing map below
 - Bans + completeness contract → `avoid-ai-slop.md`
 - Easing, durations → `motion-and-interaction.md`
 - GPU, tokens, a11y engineering → `engineering-and-performance.md`
+- Idiomatic CSS implementation, applying CSS fixes → `css-techniques.md`
 
 ## Ship gate
 

--- a/skills/designer-skill/reference/css-techniques.md
+++ b/skills/designer-skill/reference/css-techniques.md
@@ -1,0 +1,1176 @@
+# CSS Techniques
+
+Practical, modern CSS patterns for writing and fixing real stylesheets — the implementation cookbook behind the design decisions. Where `design-principles.md` and `engineering-and-performance.md` say *what* the type ramp, spacing, contrast, and responsive behavior should be, this file says *how* to express it in idiomatic CSS: resets, box-sizing inheritance, centering, `aspect-ratio`, `:is()`/`:not()`, logical properties, container queries, `:has()`, `@layer`, `clamp()`, and more. Reach for it whenever you apply CSS fixes to a site.
+
+Baseline labels (Widely / Newly / Limited available) are a browser-compatibility signal only — still verify accessibility, keyboard behavior, motion preferences, and contrast separately. Source: AllThingsSmitty/css-protips + curated Baseline additions (web.dev/MDN).
+
+Each entry is a self-contained pattern — apply the one that fits the problem in front of you.
+
+---
+
+### Use a CSS Reset
+
+CSS resets help enforce style consistency across different browsers with a clean slate for styling elements. There are plenty of reset patterns to find, or you can use a more simplified reset approach:
+
+```css
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+```
+
+Now elements will be stripped of margins and padding, and `box-sizing` lets you manage layouts with the CSS box model.
+
+#### [Demo](https://codepen.io/AllThingsSmitty/pen/kkrkLL)
+
+> [!TIP]
+> If you follow the [Inherit `box-sizing`](#inherit-box-sizing) tip below you might opt to not include the `box-sizing` property in your CSS reset.
+
+
+### Inherit `box-sizing`
+
+Let `box-sizing` be inherited from `html`:
+
+```css
+html {
+  box-sizing: border-box;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: inherit;
+}
+```
+
+This makes it easier to change `box-sizing` in plugins or other components that leverage other behavior.
+
+#### [Demo](https://css-tricks.com/inheriting-box-sizing-probably-slightly-better-best-practice/)
+
+
+### Use `all: unset` Carefully for Component Resets
+
+When resetting an element's properties, you can reset each property individually:
+
+```css
+button {
+  background: none;
+  border: none;
+  color: inherit;
+  font: inherit;
+  outline: none;
+  padding: 0;
+}
+```
+
+Or use the `all` shorthand with `unset`. **`all: unset` resets almost every property** (except
+`unicode-bidi`, `direction`, and custom properties) — inherited props revert to inherit, others to
+initial. A `<button>` becomes `display: inline` and loses its native box, so always restore layout
+and focus after unsetting.
+
+```css
+button.reset {
+  all: unset;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+button.reset:focus-visible {
+  outline: 2px solid currentColor;
+  outline-offset: 0.15em;
+}
+```
+
+> [!TIP]
+> To restore the user-agent stylesheet instead of a blank slate, use `all: revert` — see
+> [Reset intent: `unset` vs `revert`](#reset-intent-unset-vs-revert) in the Modern CSS section.
+
+
+### Use `:not()` to Apply/Unapply Borders on Navigation
+
+Instead of putting on the border...
+
+```css
+/* add border */
+.nav li {
+  border-right: 1px solid #666;
+}
+```
+
+...and then taking it off the last element...
+
+```css
+/* remove border */
+.nav li:last-child {
+  border-right: none;
+}
+```
+
+...use the `:not()` pseudo-class to only apply to the elements you want:
+
+```css
+.nav li:not(:last-child) {
+  border-right: 1px solid #666;
+}
+```
+
+Here, the CSS selector is read as a human would describe it.
+
+#### [Demo](https://codepen.io/AllThingsSmitty/pen/LkymvO)
+
+
+### Check if Font Is Installed Locally
+
+You can check if a font is installed locally before fetching it remotely, which is a good performance tip, too.
+
+```css
+@font-face {
+  font-family: "Dank Mono";
+  src:
+    /* Full name */ local("Dank Mono"), /* Postscript name */ local("Dank Mono"),
+    /* Otherwise, download it! */ url("//...a.server/fonts/DankMono.woff");
+}
+
+code {
+  font-family: "Dank Mono", system-ui-monospace;
+}
+```
+
+H/T to Adam Argyle for sharing this protip and [demo](https://codepen.io/argyleink/pen/VwYJpgR).
+
+
+### Add `line-height` to `body`
+
+You don't need to add `line-height` to each `<p>`, `<h*>`, _et al_. separately. Instead, add it to `body`:
+
+```css
+body {
+  line-height: 1.5;
+}
+```
+
+This way textual elements can inherit from `body` easily.
+
+#### [Demo](https://codepen.io/AllThingsSmitty/pen/VjbdYd)
+
+
+### Set `:focus` for Form Elements
+
+Sighted keyboard users rely on focus to determine where keyboard events go in the page. Make focus for form elements stand out and consistent than a browser's default implementation:
+
+```css
+a:focus,
+button:focus,
+input:focus,
+select:focus,
+textarea:focus {
+  box-shadow: none;
+  outline: #000 dotted 2px;
+  outline-offset: 0.05em;
+}
+```
+
+#### [Demo](https://codepen.io/AllThingsSmitty/pen/ePzoOP/)
+
+> [!TIP]
+> In modern code, prefer [`:focus-visible`](#prefer-focus-visible-over-focus) so keyboard users keep
+> a clear focus ring without showing focus styles on every mouse click.
+
+
+### Vertically-Center Anything
+
+Prefer **Grid** with a dynamic viewport unit on mobile — `100vh` maps to the large viewport and can
+misbehave when browser toolbars show/hide. With logical properties, use `100dvb` (dynamic viewport block).
+
+```css
+.center-page {
+  min-block-size: 100dvb;
+  display: grid;
+  place-items: center;
+}
+```
+
+Flexbox works the same way once the parent has a defined block size:
+
+```css
+html,
+body {
+  min-block-size: 100%;
+}
+
+body {
+  align-items: center;
+  display: flex;
+  justify-content: center;
+}
+```
+
+> [!NOTE]
+> Legacy pattern: `height: 100vh` + `place-items: center` still appears in older tutorials. Prefer
+> `dvh`/`dvb`/`svh`/`lvh` for full-viewport layouts on mobile — see MDN on viewport-relative lengths.
+
+> [!TIP]
+> Want to center something else? CSS-Tricks has [a nice write-up](https://css-tricks.com/centering-css-complete-guide/) on doing all of that.
+
+#### [Demo](https://codepen.io/AllThingsSmitty/pen/GqmGqZ)
+
+
+### Use `aspect-ratio` Instead of Height/Width
+
+The `aspect-ratio` property allows you to easily size elements and maintain consistent width-to-height ratio. This is incredibly useful in responsive web design to prevent layout shift. Use `object-fit` with it to prevent disrupting the layout if the height/width values of images changes.
+
+```css
+img {
+  aspect-ratio: 16 / 9; /* width / height */
+  object-fit: cover;
+}
+```
+
+Learn more about the `aspect-ratio` property in this [web.dev post](https://web.dev/articles/aspect-ratio).
+
+#### [Demo](https://codepen.io/AllThingsSmitty/pen/MWxwoNx/)
+
+
+### Comma-Separated Lists
+
+Make list items look like a real, comma-separated list:
+
+```css
+ul > li:not(:last-child)::after {
+  content: ",";
+}
+```
+
+Use the `:not()` pseudo-class and no comma will be added to the last item.
+
+> [!NOTE]
+> This tip may not be ideal for accessibility, specifically screen readers. And copy/paste from the browser doesn't work with CSS-generated content. Proceed with caution.
+
+
+### Select Items Using Negative `nth-child`
+
+Use negative `nth-child` in CSS to select items 1 through n.
+
+```css
+li {
+  display: none;
+}
+
+/* select items 1 through 3 and display them */
+li:nth-child(-n + 3) {
+  display: block;
+}
+```
+
+Or, since you've already learned a little about [using `:not()`](#use-not-to-applyunapply-borders-on-navigation), try:
+
+```css
+/* select all items except the first 3 and display them */
+li:not(:nth-child(-n + 3)) {
+  display: block;
+}
+```
+
+#### [Demo](https://codepen.io/AllThingsSmitty/pen/WxjKZp)
+
+
+### Use SVG for Icons
+
+There's no reason not to use SVG for icons:
+
+```css
+.logo {
+  background: url("logo.svg");
+}
+```
+
+SVG scales well for all resolution types and is supported in all browsers [back to IE9](http://caniuse.com/#search=svg). Ditch your .png, .jpg, or .gif-jif-whatev files.
+
+> [!NOTE]
+> If you have SVG icon-only buttons for sighted users and the SVG fails to load, this will help maintain accessibility:
+
+```css
+.no-svg .icon-only::after {
+  content: attr(aria-label);
+}
+```
+
+
+### Use the "Lobotomized Owl" Selector
+
+It may have a strange name but using the universal selector (`*`) with the adjacent sibling selector (`+`) can provide a powerful CSS capability:
+
+```css
+* + * {
+  margin-top: 1.5em;
+}
+```
+
+In this example, all elements in the flow of the document that follow other elements will receive `margin-top: 1.5em`.
+
+> [!TIP]
+> For more on the "lobotomized owl" selector, read [Heydon Pickering's post](http://alistapart.com/article/axiomatic-css-and-lobotomized-owls) on _A List Apart_.
+
+#### [Demo](https://codepen.io/AllThingsSmitty/pen/grRvWq)
+
+
+### Use `max-height` for Pure CSS Sliders
+
+Implement CSS-only sliders using `max-height` with overflow hidden:
+
+```css
+.slider {
+  max-height: 200px;
+  overflow-y: hidden;
+  width: 300px;
+}
+
+.slider:hover {
+  max-height: 600px;
+  overflow-y: scroll;
+}
+```
+
+The element expands to the `max-height` value on hover and the slider displays as a result of the overflow.
+
+
+### Equal-Width Table Cells
+
+Tables can be a pain to work with. Try using `table-layout: fixed` to keep cells at equal width:
+
+```css
+.calendar {
+  table-layout: fixed;
+}
+```
+
+Pain-free table layouts.
+
+#### [Demo](https://codepen.io/AllThingsSmitty/pen/jALALm)
+
+
+### Get Rid of Margin Hacks With Flexbox
+
+When working with column gutters you can get rid of `nth-`, `first-`, and `last-child` hacks by using flexbox's `space-between` property:
+
+```css
+.list {
+  display: flex;
+  justify-content: space-between;
+}
+
+.list .person {
+  flex-basis: 23%;
+}
+```
+
+Now column gutters always appear evenly-spaced.
+
+
+### Use Attribute Selectors with Empty Links
+
+Display links when the `<a>` element has no text value but the `href` attribute has a link:
+
+```css
+a[href^="http"]:empty::before {
+  content: attr(href);
+}
+```
+
+That's really convenient.
+
+#### [Demo](https://codepen.io/AllThingsSmitty/pen/zBzXRx)
+
+> [!NOTE]
+> This tip may not be ideal for accessibility, specifically screen readers. And copy/paste from the browser doesn't work with CSS-generated content. Proceed with caution.
+
+
+### Control Specificity Better with `:is()`
+
+The `:is()` pseudo-class is used to target multiple selectors at once, reducing redundancy and enhancing code readability. This is incredibly useful for writing large selectors in a more compact form.
+
+```css
+:is(section, article, aside, nav) :is(h1, h2, h3, h4, h5, h6) {
+  color: green;
+}
+```
+
+The above ruleset is equivalent to the following number selector rules...
+
+```css
+section h1,
+section h2,
+section h3,
+section h4,
+section h5,
+section h6,
+article h1,
+article h2,
+article h3,
+article h4,
+article h5,
+article h6,
+aside h1,
+aside h2,
+aside h3,
+aside h4,
+aside h5,
+aside h6,
+nav h1,
+nav h2,
+nav h3,
+nav h4,
+nav h5,
+nav h6 {
+  color: green;
+}
+```
+
+#### [Demo](https://codepen.io/AllThingsSmitty/pen/rNRVxdx)
+
+
+### Style "Default" Links
+
+Add a style for "default" links:
+
+```css
+a[href]:not([class]) {
+  color: #008000;
+  text-decoration: underline;
+}
+```
+
+Now links that are inserted via a CMS, which don't usually have a `class` attribute, will have a distinction without generically affecting the cascade.
+
+
+### Intrinsic Ratio Boxes (legacy fallback)
+
+> [!NOTE]
+> **Legacy only.** Prefer [`aspect-ratio`](#use-aspect-ratio-instead-of-heightwidth) (Baseline Widely
+> available) for new code. Keep this padding hack only when you must support very old browsers or
+> need a pattern that predates `aspect-ratio`.
+
+To create a box with an intrinsic ratio, apply top or bottom padding to a div:
+
+```css
+.container {
+  height: 0;
+  padding-bottom: 20%;
+  position: relative;
+}
+
+.container div {
+  border: 2px dashed #ddd;
+  height: 100%;
+  left: 0;
+  position: absolute;
+  top: 0;
+  width: 100%;
+}
+```
+
+Using 20% for padding makes the height of the box equal to 20% of its width. No matter the width of the viewport, the child div will keep its aspect ratio (100% / 20% = 5:1).
+
+#### [Demo](https://codepen.io/AllThingsSmitty/pen/jALZvE)
+
+
+### Style Broken Images
+
+Make broken images more aesthetically-pleasing with a little bit of CSS:
+
+```css
+img {
+  display: block;
+  font-family: sans-serif;
+  font-weight: 300;
+  height: auto;
+  line-height: 2;
+  position: relative;
+  text-align: center;
+  width: 100%;
+}
+```
+
+Now add pseudo-elements rules to display a user message and URL reference of the broken image:
+
+```css
+img::before {
+  content: "We're sorry, the image below is broken :(";
+  display: block;
+  margin-bottom: 10px;
+}
+
+img::after {
+  content: "(url: " attr(src) ")";
+  display: block;
+  font-size: 12px;
+}
+```
+
+> [!TIP]
+> Learn more about styling for this pattern in [Ire Aderinokun's post](http://bitsofco.de/styling-broken-images/).
+
+
+### Use `rem` for Global Sizing; Use `em` for Local Sizing
+
+After setting the base font size at the root (`html { font-size: 100%; }`), set the font size for textual elements to `em`:
+
+```css
+h2 {
+  font-size: 2em;
+}
+
+p {
+  font-size: 1em;
+}
+```
+
+Then set the font-size for modules to `rem`:
+
+```css
+article {
+  font-size: 1.25rem;
+}
+
+aside .module {
+  font-size: 0.9rem;
+}
+```
+
+Now each module becomes compartmentalized and easier to style, more maintainable, and flexible.
+
+
+### Hide Autoplay Videos That Aren't Muted
+
+This is a great trick for a custom user stylesheet. Avoid overloading a user with sound from a video that autoplays when the page is loaded. If the sound isn't muted, don't show the video:
+
+```css
+video[autoplay]:not([muted]) {
+  display: none;
+}
+```
+
+Once again, we're taking advantage of using the [`:not()`](#use-not-to-applyunapply-borders-on-navigation) pseudo-class.
+
+
+### Use `:root` for Flexible Type
+
+The type font size in a responsive layout should be able to adjust with each viewport. You can calculate the font size based on the viewport height and width using `:root`:
+
+```css
+:root {
+  font-size: calc(1vw + 1vh + 0.5vmin);
+}
+```
+
+Now you can utilize the `root em` unit based on the value calculated by `:root`:
+
+```css
+body {
+  font: 1rem/1.6 sans-serif;
+}
+```
+
+#### [Demo](https://codepen.io/AllThingsSmitty/pen/XKgOkR)
+
+
+### Set `font-size` on Form Elements for a Better Mobile Experience
+
+To avoid mobile browsers (iOS Safari, _et al_.) from zooming in on HTML form elements when a `<select>` drop-down is tapped, add `font-size` to the selector rule:
+
+```css
+input[type="text"],
+input[type="number"],
+select,
+textarea {
+  font-size: 16px;
+}
+```
+
+
+### Use Pointer Events to Control Mouse Events
+
+[Pointer events](https://developer.mozilla.org/en-US/docs/Web/CSS/pointer-events) control how pointer
+input hits an element. To block clicks on a disabled-looking control:
+
+```css
+button:disabled {
+  opacity: 0.5;
+  pointer-events: none;
+}
+```
+
+> [!WARNING]
+> `pointer-events: none` blocks pointer interaction, **not all interaction**. Elements with
+> `pointer-events: none` can still receive keyboard focus through Tab navigation. Do not use it as
+> your only “disabled” behavior for interactive controls. Prefer the native `disabled` attribute
+> where available.
+
+
+### Set `display: none` on Line Breaks Used as Spacing
+
+As [Harry Roberts pointed out](https://twitter.com/csswizardry/status/1170835532584235008), this can help prevent CMS users from using extra line breaks for spacing:
+
+```css
+br + br {
+  display: none;
+}
+```
+
+
+### Use `:empty` to Hide Empty HTML Elements
+
+If you have HTML elements that are empty, i.e., the content has yet to be set either by a CMS or dynamically injected (e.g., `<p class="error-message"></p>`) and it's creating unwanted space on your layout, use the `:empty` pseudo-class to hide the element on the layout.
+
+```css
+:empty {
+  display: none;
+}
+```
+
+> [!NOTE]
+> Keep in mind that elements with whitespace aren't considered empty, e.g., `<p class="error-message"> </p>`.
+
+
+## Modern CSS (Baseline 2024–2026)
+
+The tips above are evergreen. These are newer **native features that retire old hacks**. Each entry
+is bucketed by [MDN Baseline](https://developer.mozilla.org/en-US/docs/Glossary/Baseline/Compatibility)
+availability — confirm your project's Browserslist floor on [caniuse](https://caniuse.com) before
+shipping.
+
+> Baseline is a **browser-compatibility signal only**. It does not replace accessibility, usability,
+> performance, keyboard testing, or project-specific QA.
+
+### Shipping Modern CSS Safely
+
+1. Pick a Baseline target or explicit Browserslist target.
+2. Treat **Baseline Widely available** features as normal production CSS.
+3. Treat **Baseline Newly available** features as production-ready only if your audience's browser
+   floor supports them.
+4. Treat **Limited availability** features as progressive enhancement only.
+5. Use `@supports` for layout-changing enhancements.
+6. Test accessibility, motion preferences, keyboard behavior, and contrast separately from browser
+   support.
+
+Baseline can be enforced through project tooling (Browserslist, ESLint CSS plugins) — see
+[web.dev/baseline](https://web.dev/baseline).
+
+> [!TIP]
+> Gate layout-changing enhancements behind a feature query when the fallback must work:
+> ```css
+> @supports (anchor-name: --x) {
+>   /* enhanced layout */
+> }
+> ```
+
+
+### Baseline widely available (normal production CSS)
+
+Safe modern defaults for current evergreen targets: `:has()`, `@container`, native CSS nesting,
+`@layer`, `subgrid`, `color-mix()`, logical properties, `:focus-visible`, `clamp()`, `aspect-ratio`,
+and `:is()`.
+
+#### Select a Parent/Sibling with `:has()`
+
+The relational pseudo-class matches an element by its descendants or following siblings — the
+long-wished-for "parent selector." Replaces JS class-toggling for whole families of state.
+
+```css
+/* a card that contains an image gets a different layout */
+.card:has(> img) {
+  grid-template-columns: 120px 1fr;
+}
+
+/* style a field when its input is focused or invalid — no JS */
+.field:has(input:focus-visible) {
+  outline: 2px solid;
+}
+.field:has(input:user-invalid) {
+  color: #b00;
+}
+```
+
+#### Component-Level Responsive with Container Queries
+
+Media queries respond to the viewport; container queries respond to the **parent's** size, so a
+component adapts wherever you drop it. Set `container-type` on the wrapper, then `@container`.
+
+```css
+.wrapper {
+  container-type: inline-size;
+}
+
+.card {
+  grid-template-columns: 1fr;
+}
+
+@container (width > 400px) {
+  .card {
+    grid-template-columns: auto 1fr;
+  }
+}
+```
+
+#### Native CSS Nesting
+
+Nest selectors without Sass. Use `&` to make the parent reference explicit.
+
+```css
+.card {
+  padding: 1rem;
+
+  & .title {
+    font-weight: 600;
+  }
+
+  &:hover {
+    background: #f6f6f6;
+  }
+}
+```
+
+#### Tame Specificity with `@layer`
+
+Cascade layers declare order of precedence up front — later layers always win regardless of selector
+specificity. Ends the `!important` arms race between reset, base, components, and utilities.
+
+```css
+@layer reset, base, components, utilities;
+
+@layer base {
+  a {
+    color: blue;
+  }
+}
+
+@layer utilities {
+  .text-red {
+    color: red; /* wins even though it's less specific */
+  }
+}
+```
+
+#### Align Nested Grids with `subgrid`
+
+A grid item can inherit its parent's tracks with `subgrid`, so children of separate cards line up on
+a shared grid — no magic numbers.
+
+```css
+.cards {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1rem;
+}
+
+.card {
+  display: grid;
+  grid-row: span 3;
+  grid-template-rows: subgrid;
+}
+```
+
+#### Mix Colors with `color-mix()`
+
+Compute tints, shades, and translucent variants in the browser — no preprocessor — and it works with
+custom properties. Prefer a perceptual space like `oklab`/`oklch`.
+
+```css
+.btn {
+  background: var(--brand);
+}
+
+.btn:hover {
+  background: color-mix(in oklab, var(--brand) 85%, black);
+}
+
+.btn--ghost {
+  background: color-mix(in srgb, var(--brand) 12%, transparent);
+}
+```
+
+#### Use Logical Properties for Flow-Relative Layout
+
+`*-inline`/`*-block` and `inset` follow the writing mode, so the same CSS mirrors correctly for RTL
+and vertical text. Reach for these over `left`/`right`/`margin-left`.
+
+```css
+.box {
+  margin-inline: auto;
+  padding-block: 1rem;
+}
+
+.overlay {
+  position: absolute;
+  inset: 0; /* top/right/bottom/left: 0 */
+}
+```
+
+#### Prefer `:focus-visible` over `:focus`
+
+`:focus-visible` shows the focus ring only when the browser judges it useful (keyboard navigation),
+so you keep accessibility without a ring on every mouse click. A modern upgrade to the
+[`:focus` form-element tip](#set-focus-for-form-elements) above.
+
+```css
+:focus:not(:focus-visible) {
+  outline: none;
+}
+
+:focus-visible {
+  outline: #000 dotted 2px;
+  outline-offset: 0.05em;
+}
+```
+
+#### Fluid Type with `clamp()`
+
+`clamp(MIN, PREFERRED, MAX)` scales a value with the viewport but stays within bounds — a robust,
+readable replacement for the [`:root { calc(1vw + 1vh …) }` trick](#use-root-for-flexible-type)
+above, which has no floor or ceiling.
+
+```css
+h1 {
+  font-size: clamp(1.75rem, 1rem + 3vw, 3rem);
+}
+
+.section {
+  padding-block: clamp(2rem, 5vw, 5rem);
+}
+```
+
+
+### Baseline newly available (verify your support floor)
+
+Production-ready only when your browser floor supports them: `text-wrap`, `light-dark()`, `@scope`,
+`@starting-style`, anchor positioning, and `contrast-color()`.
+
+#### Better Wrapping with `text-wrap`
+
+`balance` evens out the lines of short blocks like headings; `pretty` prevents orphans and ragged
+last lines in paragraphs. One line, no `<br>` babysitting.
+
+```css
+h1,
+h2,
+.hero-title {
+  text-wrap: balance;
+}
+
+.prose p {
+  text-wrap: pretty;
+}
+```
+
+> [!NOTE]
+> Baseline **Newly available** (2024). `pretty` degrades to normal wrapping where unsupported — safe
+> progressive enhancement. Verify Firefox/Safari floors if `pretty` is required, not optional.
+
+#### One-Declaration Theming with `light-dark()`
+
+Return a different value per color scheme in a single declaration — once you opt the root into both
+schemes. No duplicated `prefers-color-scheme` block for simple value swaps.
+
+```css
+:root {
+  color-scheme: light dark;
+}
+
+body {
+  background: light-dark(#fff, #111);
+  color: light-dark(#111, #eee);
+}
+```
+
+> [!NOTE]
+> Baseline **Newly available** (2024). Solid in current Chrome/Safari/Firefox — verify your support
+> floor before dropping `prefers-color-scheme` fallbacks.
+
+#### Scope Styles with `@scope`
+
+Limit a ruleset to a subtree — and optionally stop at an inner boundary — without specificity hacks
+or BEM-style naming. Useful for component or CMS-injected markup.
+
+```css
+@scope (.card) to (.card__content) {
+  img {
+    border-radius: 8px; /* only cards, and not inside .card__content */
+  }
+}
+```
+
+> [!NOTE]
+> Baseline **Newly available** (2025).
+
+#### Flash-Free Enter Transitions with `@starting-style`
+
+Defines the "before-open" styles an element animates **from** when it's first rendered (including
+`display: none → block`, popovers, and dialogs), so entrances don't snap into place.
+
+```css
+.toast {
+  transition: opacity 0.3s, translate 0.3s;
+  opacity: 1;
+  translate: 0 0;
+}
+
+@starting-style {
+  .toast {
+    opacity: 0;
+    translate: 0 1rem;
+  }
+}
+```
+
+> [!NOTE]
+> Baseline **Newly available** (2024). To transition an element that also toggles `display`, set
+> `transition-behavior: allow-discrete`.
+
+#### Tooltips & Popovers: Anchor Positioning — Limited availability
+
+Anchor positioning is still **Limited availability** (not yet Baseline — Chromium ships it, Firefox
+and Safari lag per MDN). Treat it as progressive enhancement: ship a normal positioning fallback
+first, then enhance with `@supports`.
+
+```css
+.trigger {
+  anchor-name: --tip;
+}
+
+.tooltip {
+  position: fixed;
+  position-anchor: --tip;
+  position-area: top; /* sit above the trigger */
+  position-try-fallbacks: flip-block; /* flip below if it would clip */
+}
+
+@supports not (anchor-name: --tip) {
+  .tooltip {
+    /* fallback: absolute positioning, JS coords, or static placement */
+  }
+}
+```
+
+> [!NOTE]
+> While only Limited availability, anchor positioning still has known cross-browser bugs and missing
+> pieces (web-features maintainers tracked it as effectively "beta"; Firefox shipped it later/flagged).
+> The `@supports` fallback above is load-bearing, not decorative — keep a working non-anchored layout.
+
+#### Automatic Black/White Contrast with `contrast-color()`
+
+Picks **black or white** — whichever contrasts more with the given color — as a foreground. **Not**
+the older `color-contrast()` you'll still see in blog posts.
+
+```css
+.badge {
+  background: var(--brand);
+  color: white; /* fallback for unsupported browsers */
+}
+
+@supports (color: contrast-color(red)) {
+  .badge {
+    color: contrast-color(var(--brand));
+  }
+}
+```
+
+> [!NOTE]
+> Baseline **Newly available** (April 2026). Gate behind `@supports` for older floors.
+
+> [!WARNING]
+> Useful, but not magic: it only returns black or white, so a mid-tone background (e.g. `#2277d3`)
+> can still fail WCAG AA for small text. Use it with light/dark design tokens and still test contrast.
+
+
+### Limited availability (progressive enhancement only)
+
+MDN marks these as **Limited availability** or Interop still lists them as active focus areas. Ship
+a working baseline first; enhance behind `@supports`.
+
+#### Theme Native Controls with `accent-color`
+
+Recolor checkboxes, radios, range sliders, and progress bars to your brand in one line — keeping the
+native, accessible widgets.
+
+```css
+:root {
+  accent-color: rebeccapurple;
+}
+```
+
+> [!NOTE]
+> **Limited availability** on MDN as of 2026 — verify engine support before relying on it for brand
+> theming; provide a fallback palette for unsupported browsers.
+
+#### Scroll-Driven Animations (no scroll listeners)
+
+Drive an animation by scroll progress (`scroll()`) or an element's visibility (`view()`) — off the
+main thread, replacing `addEventListener('scroll', …)`. Interop 2026 still lists scroll-driven
+animations as an active interoperability focus area.
+
+```css
+.reveal {
+  animation: fade-in linear both;
+  animation-timeline: view();
+  animation-range: entry 0% cover 40%;
+}
+
+@keyframes fade-in {
+  from {
+    opacity: 0;
+    translate: 0 20px;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+/* always give motion an opt-out */
+@media (prefers-reduced-motion: reduce) {
+  .reveal {
+    animation: none;
+  }
+}
+```
+
+> [!NOTE]
+> Gate behind `@supports (animation-timeline: view())` and ship static content as the default.
+
+#### Auto-Sizing Inputs with `field-sizing`
+
+`field-sizing: content` lets inputs and textareas grow with their content instead of staying a fixed
+size — the autosize-textarea JS hack, in one line.
+
+```css
+textarea,
+input {
+  field-sizing: content;
+}
+```
+
+> [!NOTE]
+> **Limited availability** on MDN as of 2026. Keep a fixed `min-height` / JS autosize fallback.
+
+
+### Retire / modernize older tips
+
+Several evergreen tips above predate features that now do the job natively. The originals stay for
+context; reach for these in new code. Availability is called out where it bites — the `height: auto`
+animation in particular is **Chrome-only** as of 2026.
+
+#### Drop the padding-hack ratio box → `aspect-ratio`
+
+The [Intrinsic Ratio Boxes](#intrinsic-ratio-boxes-legacy-fallback) padding trick needs a wrapper and absolute
+positioning. [`aspect-ratio`](#use-aspect-ratio-instead-of-heightwidth) (covered above) does it on one
+element, no wrapper.
+
+```css
+.embed { aspect-ratio: 16 / 9; } /* replaces height: 0 + padding-bottom: 56.25% */
+```
+
+#### Smooth disclosure → animate grid rows, not `max-height`
+
+[`max-height` sliders](#use-max-height-for-pure-css-sliders) animate against a *guessed* ceiling, so
+the transition wastes time crossing the empty gap between the real height and the max. Animate
+`grid-template-rows` from `0fr` to `1fr` instead — widely supported, no magic number.
+
+```css
+.disclosure {
+  display: grid;
+  grid-template-rows: 0fr;
+  transition: grid-template-rows 0.3s ease;
+}
+.disclosure.is-open { grid-template-rows: 1fr; }
+.disclosure > * { overflow: hidden; } /* min-height: 0 so the row can collapse */
+```
+
+> [!NOTE]
+> A true `height: 0 → auto` transition needs `interpolate-size: allow-keywords` (or `calc-size(auto)`),
+> which is **Chrome 129+ only** as of 2026 — not Baseline. Use it as progressive enhancement; other
+> browsers just snap. `transition-behavior: allow-discrete` alone will **not** interpolate `height` —
+> it only governs discrete properties like `display`.
+
+#### Even columns → `auto-fit` grid, not `space-between` + `%`
+
+[`justify-content: space-between` with `flex-basis: 23%`](#get-rid-of-margin-hacks-with-flexbox) snaps
+a partly-filled last row to the edges (e.g. 2 items in a 4-up row fly to opposite ends). An `auto-fit`
+grid keeps every row aligned, complete or not.
+
+```css
+.list {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1.5rem;
+}
+```
+
+#### Reset intent: `unset` vs `revert`
+
+These aren't interchangeable — pick by what you want. [`all: unset`](#use-all-unset-carefully-for-component-resets)
+gives a clean slate but sends non-inherited props to their *initial* values, so a `<button>` becomes
+`display: inline` and loses its box. `all: revert` rolls back to the user-agent stylesheet — which
+keeps the button's box **and** its native border/background, so it's "undo my styles," not "strip to
+nothing."
+
+```css
+button { all: unset; display: inline-block; } /* clean slate, then fix the box */
+button { all: revert; }                        /* restore the native button look */
+```
+
+#### Don't `local()` brand fonts
+
+The [local-font check](#check-if-font-is-installed-locally) can match a *stale* user-installed copy
+with different metrics, causing layout shift (CLS). For brand type, self-host an optimized `.woff2`
+with `font-display: swap` and a metric-matching `size-adjust` descriptor; reserve `local()` for system
+fonts via a `system-ui` stack.
+
+#### Scope the owl → `.flow`
+
+A global [`* + *`](#use-the-lobotomized-owl-selector) leaks margins into third-party widgets and grid
+children. Scope it to a flow utility (and use a logical property while you're there).
+
+```css
+.flow > * + * { margin-block-start: 1.5em; }
+```
+
+#### Recolorable icons → `mask`, not `background`
+
+[`background: url(icon.svg)`](#use-svg-for-icons) can't be recolored from CSS. For monochrome icons,
+`mask` the SVG and paint with `currentColor` so it inherits text color. (Keep `background`/inline SVG
+for multicolor art.)
+
+```css
+.icon {
+  width: 24px;
+  height: 24px;
+  background-color: currentColor; /* the icon's color */
+  mask: url("icon.svg") no-repeat center / contain;
+}
+```
+
+#### Two quick selector upgrades
+
+```css
+/* scoped nth-child: count only .item children, ignoring other siblings */
+li:nth-child(-n + 3 of .item) { display: block; }
+
+/* zero-specificity default links — trivial to override in components later */
+:where(a[href]:not([class])) {
+  color: #008000;
+  text-decoration: underline;
+}
+```
+
+
+
+---
+
+<!-- Provenance: derived from AllThingsSmitty/css-protips (MIT) @ commit e95123993037bbcd1bd97170cfa02087155c3690.
+     The "Modern CSS (Baseline 2024–2026)" section and several in-place modernizations (all: unset reset,
+     100dvh centering, pointer-events a11y note) are local additions curated from web.dev Baseline / MDN /
+     Interop 2026 — not upstream. Preserve them on any re-sync of the upstream mirror. -->


### PR DESCRIPTION
Integrates the css-protips cookbook into designer-skill as a first-class reference so the agent applies idiomatic, modern CSS when designing and fixing styles.

## What

- **New `reference/css-techniques.md`** — derived from AllThingsSmitty/css-protips (MIT) plus local Baseline 2024–2026 additions; provenance noted in-file. Registered in `skill.ts`, so it flows automatically to the `get_reference` enum and the MCP resource list.
- **`dispatch.ts`** — new `css` verb, and `css-techniques` routed into the implementation-heavy verbs (`check`, `finish`, `ship`, `speed`, `layout`, `responsive`, `refresh`). `build`/`plan` stay lean; the SKILL.md *Implement* step instead points the agent to pull `css-techniques` when writing CSS, so the 31k cookbook is not auto-loaded into every build request.
- **`SKILL.md`** — routing-map row, cross-file-ownership line, count → fifteen.
- **`server.ts` + tests** — count → fifteen; added a dispatch test asserting CSS-fix requests route to `css-techniques`.
- **READMEs** — added the `css-techniques` row and reconciled the reference count to **15**, restoring the previously-missing `differentiation-playbook` row (badges/counts had been stale at 13).
- Removed the standalone `skills/css-pro-tips/` skill (folded in; the reference is now the single source).

## Verification

`npm run build && npm test` → **56/56 pass**.

## Follow-up (not blocking)

Consider a formal `NOTICE` entry for the bundled CSS content at the next npm release; current attribution is the in-file `Source:`/provenance credit + repo-root MIT LICENSE.